### PR TITLE
docs: add example of custom namespace prefixes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ This repository contains a set of stored procedures and extensions to both produ
 | nodeCacheSize      | integer (10000) | keep n nodes in cache to minimize reads from DB |
 
 
+### Namespace prefixes
+If `shortenUrls == true`, you'll have prefixes used to shorten property and relationship names; and labels. You don't need to define your own namespaces prefixes as ones will be automatically generated for you such as `ns0`, `ns1`, etc. If you're coming from the RDF and SPARQL world and you're used to defining your own prefixes, you can do so here too. You need to create a `NamesapcePrefixDefinition` node before you perform the load of RDF data:
+
+    // create the prefix mapping
+    CREATE (rdf:NamespacePrefixDefinition {
+      `http://www.example.com/ontology/1.0.0#`: 'ex',
+      `http://www.w3.org/1999/02/22-rdf-syntax-ns#`: 'rdfs'})
+    // do the load. Note 'shortenUrls' defaults to true but we're just being explicit
+    CALL semantics.importRDF("file:///path/to/some-file.ttl", "Turtle", {shortenUrls: true})
+
+
 ### Extensions
 
 | Extension        | params           | Description and example usage  |


### PR DESCRIPTION
Thought this would be a useful addition to the README