### PR TITLE
Fix: fix bug with cache miss lookup for 'object' part of statement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
 *.iml
+.classpath
+.project
+.settings/

--- a/src/main/java/semantics/DirectStatementLoader.java
+++ b/src/main/java/semantics/DirectStatementLoader.java
@@ -262,7 +262,7 @@ class DirectStatementLoader implements RDFHandler, Callable<Integer> {
             final Node toNode = nodeCache.get(st.getObject().stringValue(), new Callable<Node>() {
                 @Override
                 public Node call() {  //throws AnyException
-                    return graphdb.findNode(RESOURCE, "uri", st.getSubject().stringValue());
+                    return graphdb.findNode(RESOURCE, "uri", st.getObject().stringValue());
                 }
             });
 

--- a/src/test/resources/myrdf/testImportTurtle02.ttl
+++ b/src/test/resources/myrdf/testImportTurtle02.ttl
@@ -1,0 +1,14 @@
+@prefix :      <http://www.example.com/ontology/1.0.0#> .
+@prefix common: <http://www.example.com/ontology/1.0.0/common#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix project: <http://www.example.com/ontology/1.0.0/project#> .
+
+project:DISTANCEVALUE-A181457
+        a       :DISTANCEVALUE ;
+        :units  common:MEASUREMENTUNIT-T1510615421640 ;
+        :value  0.55 .
+
+common:MEASUREMENTUNIT-T1510615421640
+        a               :MEASUREMENTUNIT ;
+        :name           "metres" .


### PR DESCRIPTION
Firstly, thanks for the super useful plugin. I was seeing some weird behaviour when loading ~35 million triples where most relationships I looked at were wrong. They either pointed back to the same node or where they pointed to another node, it wasn't the right one.

I eventually traced it back to a cache miss and in the lookup, there was a typo that used the `subject` of the triple, not the `object` like it should.

I've committed a failing test and then the fix for it so you can verify.

Steps to reproduce:
 1. perform a load with the cache size set to lower than the number of triples to load (so we get cache misses)

Expected behaviour:
The loaded graph has the same relationships as the source RDF.

Actual behaviour:
Many relationships in the Neo4J graph don't mirror the RDF. They either point back to the same node (self relationship) or point to another, wrong node.