### PR TITLE
align jackson version and upgrade to 3.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,10 @@
 
 	<groupId>org.neo4j</groupId>
 	<artifactId>neosemantics</artifactId>
-	<version>3.3.1.1-SNAPSHOT</version>
+	<version>3.3.2.1-SNAPSHOT</version>
+	<packaging>jar</packaging>
 	<properties>
-		<neo4j.version>3.3.1</neo4j.version>
+		<neo4j.version>3.3.2</neo4j.version>
 		<sesame.version>4.1.1</sesame.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
@@ -68,6 +69,14 @@
 			<version>2.0</version>
 			<scope>provided</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.9.0</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>org.neo4j</groupId>
 			<artifactId>neo4j-io</artifactId>
@@ -121,17 +130,15 @@
 						</goals>
 						<configuration>
 							<transformers>
-								<transformer
-									implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
 							</transformers>
 						</configuration>
 					</execution>
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
+				<version>3.5.1</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>


### PR DESCRIPTION
Hi @jbarrasa 

In some cases (depending the order of classes loading), it might clash with different jackson versions used by popular neo4j plugins such as APOC and the GraphAware modules.

This PR aligns the jackson version to 2.9 as well as upgrade the dependency to neo 3.3.2.