### PR TITLE
'verifyUriSyntax' option which can disable import failures on bad uris

### DIFF
--- a/src/main/java/semantics/RDFImport.java
+++ b/src/main/java/semantics/RDFImport.java
@@ -27,6 +27,7 @@ import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
@@ -101,6 +102,8 @@ public class RDFImport {
         .get("nodeCacheSize") : DEFAULT_NODE_CACHE_SIZE);
     final String languageFilter = (props.containsKey("languageFilter") ? (String) props
         .get("languageFilter") : null);
+    final boolean verifyUriSyntax = (props.containsKey("verifyUriSyntax") ? (Boolean) props
+            .get("verifyUriSyntax") : true);
 
     ImportResults importResults = new ImportResults();
 
@@ -115,6 +118,7 @@ public class RDFImport {
       checkIndexesExist();
       InputStream inputStream = getInputStream(url, props);
       RDFParser rdfParser = Rio.createParser(getFormat(format));
+      rdfParser.set(BasicParserSettings.VERIFY_URI_SYNTAX, verifyUriSyntax);
       rdfParser.setRDFHandler(statementLoader);
       rdfParser.parse(inputStream, url);
     } catch (MalformedURLException e) {
@@ -196,6 +200,8 @@ public class RDFImport {
         .get("keepLangTag") : false);
     final String languageFilter = (props.containsKey("languageFilter") ? (String) props
         .get("languageFilter") : null);
+    final boolean verifyUriSyntax = (props.containsKey("verifyUriSyntax") ? (Boolean) props
+            .get("verifyUriSyntax") : true);
 
     Map<String, Node> virtualNodes = new HashMap<>();
     List<Relationship> virtualRels = new ArrayList<>();
@@ -211,6 +217,7 @@ public class RDFImport {
       RDFFormat rdfFormat = getFormat(format);
       log.info("Data set to be parsed as " + rdfFormat);
       RDFParser rdfParser = Rio.createParser(rdfFormat);
+      rdfParser.set(BasicParserSettings.VERIFY_URI_SYNTAX, verifyUriSyntax);
       rdfParser.setRDFHandler(statementViewer);
       rdfParser.parse(inputStream, "http://neo4j.com/base/");
     } catch (MalformedURLException e) {
@@ -228,6 +235,8 @@ public class RDFImport {
   @Procedure(mode = Mode.READ)
   public Stream<StreamedStatement> streamRDF(@Name("url") String url, @Name("format") String format,
       @Name(value = "params", defaultValue = "{}") Map<String, Object> props) {
+    final boolean verifyUriSyntax = (props.containsKey("verifyUriSyntax") ? (Boolean) props
+            .get("verifyUriSyntax") : true);
 
     StatementStreamer statementStreamer = new StatementStreamer();
     try {
@@ -236,6 +245,7 @@ public class RDFImport {
       RDFFormat rdfFormat = getFormat(format);
       log.info("Data set to be parsed as " + rdfFormat);
       RDFParser rdfParser = Rio.createParser(rdfFormat);
+      rdfParser.set(BasicParserSettings.VERIFY_URI_SYNTAX, verifyUriSyntax);
       rdfParser.setRDFHandler(statementStreamer);
       rdfParser.parse(inputStream, "http://neo4j.com/base/");
     } catch (MalformedURLException e) {
@@ -270,6 +280,8 @@ public class RDFImport {
         .get("keepLangTag") : false);
     final String languageFilter = (props.containsKey("languageFilter") ? (String) props
         .get("languageFilter") : null);
+    final boolean verifyUriSyntax = (props.containsKey("verifyUriSyntax") ? (Boolean) props
+            .get("verifyUriSyntax") : true);
 
     Map<String, Node> virtualNodes = new HashMap<>();
     List<Relationship> virtualRels = new ArrayList<>();
@@ -285,6 +297,7 @@ public class RDFImport {
       RDFFormat rdfFormat = getFormat(format);
       log.info("Data set to be parsed as " + rdfFormat);
       RDFParser rdfParser = Rio.createParser(rdfFormat);
+      rdfParser.set(BasicParserSettings.VERIFY_URI_SYNTAX, verifyUriSyntax);
       rdfParser.setRDFHandler(statementViewer);
       rdfParser.parse(inputStream, "http://neo4j.com/base/");
     } catch (MalformedURLException e) {

--- a/src/test/java/semantics/RDFImportTest.java
+++ b/src/test/java/semantics/RDFImportTest.java
@@ -61,6 +61,11 @@ public class RDFImportTest {
       "show:218 show:localName \"Cette Série des Années Soixante-dix\"@fr . \n" +
       "show:218 show:localName \"Cette Série des Années Septante\"@fr-be .  # literal with a region subtag";
 
+  String wrongUriTtl = "@prefix pr: <http://example.org/vocab/show/> .\n" +
+          "pr:ent" +
+          "      pr:P854 <https://suasprod.noc-science.at/XLCubedWeb/WebForm/ShowReport.aspx?rep=004+studierende%2f001+universit%u00e4ten%2f003+studierende+nach+universit%u00e4ten.xml&toolbar=true> ;\n" +
+          "      pr:P813 \"2017-10-11T00:00:00Z\"^^xsd:dateTime .\n";
+
   @Rule
   public Neo4jRule neo4j = new Neo4jRule()
       .withProcedure(RDFImport.class).withFunction(RDFImport.class)
@@ -276,6 +281,56 @@ public class RDFImportTest {
               "RETURN n.`http://neo4j.com/voc/` as prefix")
               .next().get("prefix").asString());
 
+    }
+  }
+
+  @Test
+  public void testImportBadUrisTtl() throws Exception {
+    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
+            Config.build().withEncryptionLevel(Config.EncryptionLevel.NONE).toConfig())) {
+
+      Session session = driver.session();
+      createIndices(neo4j.getGraphDatabaseService());
+
+      session.run("WITH {`http://example.org/vocab/show/`:'pr' } as nslist\n" +
+              "MERGE (n:NamespacePrefixDefinition)\n" +
+              "SET n+=nslist " +
+              "RETURN n ");
+
+      StatementResult importResults1 = session.run("CALL semantics.importRDF('" +
+              RDFImportTest.class.getClassLoader().getResource("badUri.ttl")
+                      .toURI()
+              + "','Turtle',{ handleVocabUris: 'SHORTEN', typesToLabels: true, commitSize: 500, verifyUriSyntax: false})");
+      assertEquals(2L, importResults1.next().get("triplesLoaded").asLong());
+      assertEquals("test name",
+              session.run("MATCH (jb {uri: 'http://example.org/vocab/show/ent'}) RETURN jb.pr"
+                      + PREFIX_SEPARATOR + "name AS name")
+                      .next().get("name").asString());
+    }
+  }
+
+  @Test
+  public void testImportTtlBadUrisException() throws Exception {
+    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
+            Config.build().withEncryptionLevel(Config.EncryptionLevel.NONE).toConfig())) {
+
+      Session session = driver.session();
+      createIndices(neo4j.getGraphDatabaseService());
+
+      session.run("WITH {`http://example.org/vocab/show/`:'pr' } as nslist\n" +
+              "MERGE (n:NamespacePrefixDefinition)\n" +
+              "SET n+=nslist " +
+              "RETURN n ");
+
+      StatementResult importResults1 = session.run("CALL semantics.importRDF('" +
+              RDFImportTest.class.getClassLoader().getResource("badUri.ttl")
+                      .toURI()
+              + "','Turtle',{ handleVocabUris: 'SHORTEN', typesToLabels: true, commitSize: 500})");
+      assertEquals(0, importResults1.next().get("triplesLoaded").asLong());
+      assertEquals(false,
+              session.run("MATCH (jb {uri: 'http://example.org/vocab/show/ent'}) RETURN jb.pr"
+                      + PREFIX_SEPARATOR + "name AS name")
+                      .hasNext());
     }
   }
 
@@ -523,6 +578,44 @@ public class RDFImportTest {
   }
 
   @Test
+  public void testPreviewFromSnippetPassWrongUri() throws Exception {
+    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
+            Config.build().withEncryptionLevel(Config.EncryptionLevel.NONE).toConfig())) {
+
+      Session session = driver.session();
+      createIndices(neo4j.getGraphDatabaseService());
+
+      StatementResult importResults1 = session
+              .run("CALL semantics.previewRDFSnippet('" + wrongUriTtl
+                      + "','Turtle',{ handleVocabUris: 'KEEP', typesToLabels: false, verifyUriSyntax: false})");
+      Map<String, Object> next = importResults1.next().asMap();
+      final List<Node> nodes = (List<Node>) next.get("nodes");
+      assertEquals(2, nodes.size());
+      final List<Relationship> rels = (List<Relationship>) next.get("relationships");
+      assertEquals(1, rels.size());
+    }
+  }
+
+  @Test
+  public void testPreviewFromSnippetFailWrongUri() throws Exception {
+    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
+            Config.build().withEncryptionLevel(Config.EncryptionLevel.NONE).toConfig())) {
+
+      Session session = driver.session();
+      createIndices(neo4j.getGraphDatabaseService());
+
+      StatementResult importResults1 = session
+              .run("CALL semantics.previewRDFSnippet('" + wrongUriTtl
+                      + "','Turtle',{ handleVocabUris: 'KEEP', typesToLabels: false})");
+      Map<String, Object> next = importResults1.next().asMap();
+      final List<Node> nodes = (List<Node>) next.get("nodes");
+      assertEquals(0, nodes.size());
+      final List<Relationship> rels = (List<Relationship>) next.get("relationships");
+      assertEquals(0, rels.size());
+    }
+  }
+
+  @Test
   public void testPreviewFromSnippet() throws Exception {
     try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
         Config.build().withEncryptionLevel(Config.EncryptionLevel.NONE).toConfig())) {
@@ -584,6 +677,46 @@ public class RDFImportTest {
       assertEquals(15, nodes.size());
       final List<Relationship> rels = (List<Relationship>) next.get("relationships");
       assertEquals(15, rels.size());
+    }
+  }
+
+  @Test
+  public void testPreviewFromBadUriFile() throws Exception {
+    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
+            Config.build().withEncryptionLevel(Config.EncryptionLevel.NONE).toConfig())) {
+
+      Session session = driver.session();
+      createIndices(neo4j.getGraphDatabaseService());
+
+      StatementResult importResults1 = session.run("CALL semantics.previewRDF('" +
+              RDFImportTest.class.getClassLoader()
+                      .getResource("badUri.ttl")
+                      .toURI() + "','Turtle',{ handleVocabUris: 'KEEP', typesToLabels: false, verifyUriSyntax: false})");
+      Map<String, Object> next = importResults1.next().asMap();
+      final List<Node> nodes = (List<Node>) next.get("nodes");
+      assertEquals(2, nodes.size());
+      final List<Relationship> rels = (List<Relationship>) next.get("relationships");
+      assertEquals(1, rels.size());
+    }
+  }
+
+  @Test
+  public void testPreviewFromBadUriFileFail() throws Exception {
+    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
+            Config.build().withEncryptionLevel(Config.EncryptionLevel.NONE).toConfig())) {
+
+      Session session = driver.session();
+      createIndices(neo4j.getGraphDatabaseService());
+
+      StatementResult importResults1 = session.run("CALL semantics.previewRDF('" +
+              RDFImportTest.class.getClassLoader()
+                      .getResource("badUri.ttl")
+                      .toURI() + "','Turtle',{ handleVocabUris: 'KEEP', typesToLabels: false})");
+      Map<String, Object> next = importResults1.next().asMap();
+      final List<Node> nodes = (List<Node>) next.get("nodes");
+      assertEquals(0, nodes.size());
+      final List<Relationship> rels = (List<Relationship>) next.get("relationships");
+      assertEquals(0, rels.size());
     }
   }
 
@@ -777,6 +910,40 @@ public class RDFImportTest {
       assertEquals(true, next.get("isLiteral"));
       assertEquals("http://www.w3.org/2001/XMLSchema#string", next.get("literalType"));
       assertNull(next.get("literalLang"));
+    }
+  }
+
+  @Test
+  public void testStreamFromBadUriFile() throws Exception {
+    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
+            Config.build().withEncryptionLevel(Config.EncryptionLevel.NONE).toConfig())) {
+
+      Session session = driver.session();
+      createIndices(neo4j.getGraphDatabaseService());
+
+      StatementResult importResults1 = session.run("CALL semantics.streamRDF('" +
+              RDFImportTest.class.getClassLoader().getResource("badUri.ttl")
+                      .toURI() + "','Turtle',{verifyUriSyntax: false})");
+      Map<String, Object> next = importResults1.next().asMap();
+      assertEquals("http://example.org/vocab/show/ent", next.get("subject"));
+      assertEquals("http://example.org/vocab/show/P854", next.get("predicate"));
+      assertEquals("https://suasprod.noc-science.at/XLCubedWeb/WebForm/ShowReport.aspx?rep=004+studierende%2f001+universit%25u00e4", next.get("object"));
+      assertEquals(false, next.get("isLiteral"));
+    }
+  }
+
+  @Test
+  public void testStreamFromBadUriFileFail() throws Exception {
+    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
+            Config.build().withEncryptionLevel(Config.EncryptionLevel.NONE).toConfig())) {
+
+      Session session = driver.session();
+      createIndices(neo4j.getGraphDatabaseService());
+
+      StatementResult importResults1 = session.run("CALL semantics.streamRDF('" +
+              RDFImportTest.class.getClassLoader().getResource("badUri.ttl")
+                      .toURI() + "','Turtle',{})");
+      assertEquals(false, importResults1.hasNext());
     }
   }
 

--- a/src/test/resources/badUri.ttl
+++ b/src/test/resources/badUri.ttl
@@ -1,0 +1,4 @@
+@prefix pr: <http://example.org/vocab/show/> .
+pr:ent
+      pr:P854 <https://suasprod.noc-science.at/XLCubedWeb/WebForm/ShowReport.aspx?rep=004+studierende%2f001+universit%u00e4> ;
+      pr:name "test name" .


### PR DESCRIPTION
Using the plugin we encountered an issue that it fails importing if encounters bad uri. 
In our case we can not fix all the wrong uris and there is no guarantee for always right uris in our dataset.
I have added optional option 'verifyUriSyntax' which can disable uri syntax check which is done by default.

It would be fine if we could issue a release in a week or so.